### PR TITLE
security: resolve GHSA-p6gq-j5cr-w38f - update nodemailer to 7.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "multer": "^2.0.1",
     "mysql": "^2.18.1",
     "mysql2": "^3.12.0",
-    "nodemailer": "^7.0.7",
+    "nodemailer": "^7.2.0",
     "session": "^0.1.0",
     "setinterval": "^0.2.4",
     "sharp": "^0.32.6",


### PR DESCRIPTION
What was fixed:

The message-level raw option in older versions of nodemailer bypassed the disableFileAccess and disableUrlAccess protections
This allowed arbitrary file reads and full-response SSRF attacks in delivered messages
Version 7.2.0 patches this vulnerability